### PR TITLE
feat: add option to provide a config file path, update default conf l…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,9 @@ jobs:
         echo "APPNAME=PY_EXPANSE" > nsgrest.conf
         echo "URL=https://nsgr.sdsc.edu:8443/cipresrest/v1" >> nsgrest.conf
 
-        echo "USERNAME=%NSGR_USERNAME%" >> nsgrest.conf
-        echo "PASSWORD=%NSGR_PASSWORD%" >> nsgrest.conf
-        echo "APPID=%NSGR_APPID%" >> nsgrest.conf
+        echo "USERNAME="%NSGR_USERNAME% >> nsgrest.conf
+        echo "PASSWORD="%NSGR_PASSWORD% >> nsgrest.conf
+        echo "APPID="%NSGR_APPID% >> nsgrest.conf
 
         more nsgrest.conf # print contents so far...
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,14 +38,14 @@ jobs:
         NSGR_PASSWORD: ${{ secrets.NSGR_PASSWORD }}
         NSGR_APPID: ${{ secrets.NSGR_APPID }}
       run: |
-        echo "APPNAME=PY_EXPANSE" > ~/nsgrest.conf
-        echo "URL=https://nsgr.sdsc.edu:8443/cipresrest/v1" >> ~/nsgrest.conf
+        echo "APPNAME=PY_EXPANSE" > ./nsgrest.conf
+        echo "URL=https://nsgr.sdsc.edu:8443/cipresrest/v1" >> ./nsgrest.conf
 
-        more ~/nsgrest.conf # print contents so far...
+        more ./nsgrest.conf # print contents so far...
 
-        echo "USERNAME=${NSGR_USERNAME}" >> ~/nsgrest.conf
-        echo "PASSWORD=${NSGR_PASSWORD}" >> ~/nsgrest.conf
-        echo "APPID=${NSGR_APPID}" >> ~/nsgrest.conf
+        echo "USERNAME=${NSGR_USERNAME}" >> ./nsgrest.conf
+        echo "PASSWORD=${NSGR_PASSWORD}" >> ./nsgrest.conf
+        echo "APPID=${NSGR_APPID}" >> ./nsgrest.conf
 
     - name: Version info
       run: |
@@ -53,9 +53,8 @@ jobs:
 
     - name: Test listing
       run: |
-        nsgr_job -l
+        nsgr_job -c ./nsgrest.conf -l
 
-    - name: Test submission        
-      if: ${{ matrix.runs-on != 'windows-latest' }}
+    - name: Test submission
       run: |
-        cd example/ && nsgr_submit . validate && nsgr_submit . run && cd NGBW* && tar -xvf output.tar.gz && echo ; echo ; echo "Output file contents:" ; echo && cat example_dir/output.txt
+        cd example/ && nsgr_submit -c ./nsgrest.conf . validate && nsgr_submit -c ./nsgrest.conf . run && cd NGBW* && tar -xvf output.tar.gz && echo ; echo ; echo "Output file contents:" ; echo && cat example_dir/output.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         NSGR_USERNAME: ${{ secrets.NSGR_USERNAME }}
         NSGR_PASSWORD: ${{ secrets.NSGR_PASSWORD }}
         NSGR_APPID: ${{ secrets.NSGR_APPID }}
-      if: ${{ matrix.runs-on == 'windows-latest'  }}
+      if: ${{ matrix.runs-on != 'windows-latest'  }}
       run: |
         echo "APPNAME=PY_EXPANSE" > nsgrest.conf
         echo "URL=https://nsgr.sdsc.edu:8443/cipresrest/v1" >> nsgrest.conf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,12 @@ jobs:
       run: |
         pip install .
 
-    - name: Set up config
+    - name: Set up config: non windows
       env:
         NSGR_USERNAME: ${{ secrets.NSGR_USERNAME }}
         NSGR_PASSWORD: ${{ secrets.NSGR_PASSWORD }}
         NSGR_APPID: ${{ secrets.NSGR_APPID }}
+      if: ${{ matrix.runs-on == 'windows-latest'  }}
       run: |
         echo "APPNAME=PY_EXPANSE" > nsgrest.conf
         echo "URL=https://nsgr.sdsc.edu:8443/cipresrest/v1" >> nsgrest.conf
@@ -47,6 +48,22 @@ jobs:
         echo "PASSWORD=${NSGR_PASSWORD}" >> nsgrest.conf
         echo "APPID=${NSGR_APPID}" >> nsgrest.conf
 
+    - name: Set up config: windows
+      env:
+        NSGR_USERNAME: ${{ secrets.NSGR_USERNAME }}
+        NSGR_PASSWORD: ${{ secrets.NSGR_PASSWORD }}
+        NSGR_APPID: ${{ secrets.NSGR_APPID }}
+      if: ${{ matrix.runs-on == 'windows-latest'  }}
+      run: |
+        echo "APPNAME=PY_EXPANSE" > nsgrest.conf
+        echo "URL=https://nsgr.sdsc.edu:8443/cipresrest/v1" >> nsgrest.conf
+
+        more nsgrest.conf # print contents so far...
+
+        echo "USERNAME=%NSGR_USERNAME%" >> nsgrest.conf
+        echo "PASSWORD=%NSGR_PASSWORD%" >> nsgrest.conf
+        echo "APPID=%NSGR_APPID%" >> nsgrest.conf
+
     - name: Version info
       run: |
         pip list
@@ -55,6 +72,12 @@ jobs:
       run: |
         nsgr_job -c nsgrest.conf -l
 
-    - name: Test submission
+    - name: Test submission: non windows
+      if: ${{ matrix.runs-on != 'windows-latest'  }}
       run: |
-        cd example && nsgr_submit -c nsgrest.conf . validate && nsgr_submit -c nsgrest.conf . run && cd NGBW* && tar -xvf output.tar.gz && echo ; echo ; echo "Output file contents:" ; echo && cd example_dir && cat output.txt
+        cd example && nsgr_submit -c ../nsgrest.conf . validate && nsgr_submit -c ../nsgrest.conf . run && cd NGBW* && tar -xvf output.tar.gz && echo "" && echo "" && echo "Output file contents:" && echo "" && cd example_dir && cat output.txt
+
+    - name: Test submission: windows
+      if: ${{ matrix.runs-on == 'windows-latest'  }}
+      run: |
+        cd example && nsgr_submit -c ..\nsgrest.conf . validate && nsgr_submit -c ..\nsgrest.conf . run && cd NGBW* && tar -xvf output.tar.gz && echo "" && echo "" &&  echo "Output file contents:" && echo "" && cd example_dir && cat output.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,9 @@ jobs:
         echo "APPNAME=PY_EXPANSE" > nsgrest.conf
         echo "URL=https://nsgr.sdsc.edu:8443/cipresrest/v1" >> nsgrest.conf
 
-        echo "USERNAME="%NSGR_USERNAME% >> nsgrest.conf
-        echo "PASSWORD="%NSGR_PASSWORD% >> nsgrest.conf
-        echo "APPID="%NSGR_APPID% >> nsgrest.conf
+        echo USERNAME=%NSGR_USERNAME% >> nsgrest.conf
+        echo PASSWORD=%NSGR_PASSWORD% >> nsgrest.conf
+        echo APPID=%NSGR_APPID% >> nsgrest.conf
 
         more nsgrest.conf # print contents so far...
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,14 +38,14 @@ jobs:
         NSGR_PASSWORD: ${{ secrets.NSGR_PASSWORD }}
         NSGR_APPID: ${{ secrets.NSGR_APPID }}
       run: |
-        echo "APPNAME=PY_EXPANSE" > ./nsgrest.conf
-        echo "URL=https://nsgr.sdsc.edu:8443/cipresrest/v1" >> ./nsgrest.conf
+        echo "APPNAME=PY_EXPANSE" > nsgrest.conf
+        echo "URL=https://nsgr.sdsc.edu:8443/cipresrest/v1" >> nsgrest.conf
 
-        more ./nsgrest.conf # print contents so far...
+        more nsgrest.conf # print contents so far...
 
-        echo "USERNAME=${NSGR_USERNAME}" >> ./nsgrest.conf
-        echo "PASSWORD=${NSGR_PASSWORD}" >> ./nsgrest.conf
-        echo "APPID=${NSGR_APPID}" >> ./nsgrest.conf
+        echo "USERNAME=${NSGR_USERNAME}" >> nsgrest.conf
+        echo "PASSWORD=${NSGR_PASSWORD}" >> nsgrest.conf
+        echo "APPID=${NSGR_APPID}" >> nsgrest.conf
 
     - name: Version info
       run: |
@@ -53,8 +53,8 @@ jobs:
 
     - name: Test listing
       run: |
-        nsgr_job -c ./nsgrest.conf -l
+        nsgr_job -c nsgrest.conf -l
 
     - name: Test submission
       run: |
-        cd example/ && nsgr_submit -c ./nsgrest.conf . validate && nsgr_submit -c ./nsgrest.conf . run && cd NGBW* && tar -xvf output.tar.gz && echo ; echo ; echo "Output file contents:" ; echo && cat example_dir/output.txt
+        cd example && nsgr_submit -c nsgrest.conf . validate && nsgr_submit -c nsgrest.conf . run && cd NGBW* && tar -xvf output.tar.gz && echo ; echo ; echo "Output file contents:" ; echo && cd example_dir && cat output.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,12 @@ jobs:
         echo "APPNAME=PY_EXPANSE" > nsgrest.conf
         echo "URL=https://nsgr.sdsc.edu:8443/cipresrest/v1" >> nsgrest.conf
 
-        echo USERNAME=%NSGR_USERNAME% >> nsgrest.conf
-        echo PASSWORD=%NSGR_PASSWORD% >> nsgrest.conf
-        echo APPID=%NSGR_APPID% >> nsgrest.conf
+        $outtext_username = "USERNAME=$($env:NSGR_USERNAME)"
+        $outtext_username | Out-File -FilePath "nsgrest.conf" -Append
+        $outtext_password = "PASSWORD=$($env:NSGR_PASSWORD)"
+        $outtext_password | Out-File -FilePath "nsgrest.conf" -Append
+        $outtext_appid = "APPID=$($env:NSGR_APPID)"
+        $outtext_appid | Out-File -FilePath "nsgrest.conf" -Append
 
         more nsgrest.conf # print contents so far...
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,11 @@ jobs:
         echo "APPNAME=PY_EXPANSE" > nsgrest.conf
         echo "URL=https://nsgr.sdsc.edu:8443/cipresrest/v1" >> nsgrest.conf
 
-        more nsgrest.conf # print contents so far...
-
         echo "USERNAME=${NSGR_USERNAME}" >> nsgrest.conf
         echo "PASSWORD=${NSGR_PASSWORD}" >> nsgrest.conf
         echo "APPID=${NSGR_APPID}" >> nsgrest.conf
+
+        more nsgrest.conf # print contents so far...
 
     - name: Set up config windows
       env:
@@ -58,11 +58,11 @@ jobs:
         echo "APPNAME=PY_EXPANSE" > nsgrest.conf
         echo "URL=https://nsgr.sdsc.edu:8443/cipresrest/v1" >> nsgrest.conf
 
-        more nsgrest.conf # print contents so far...
-
         echo "USERNAME=%NSGR_USERNAME%" >> nsgrest.conf
         echo "PASSWORD=%NSGR_PASSWORD%" >> nsgrest.conf
         echo "APPID=%NSGR_APPID%" >> nsgrest.conf
+
+        more nsgrest.conf # print contents so far...
 
     - name: Version info
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         pip install .
 
-    - name: Set up config: non windows
+    - name: Set up config non windows
       env:
         NSGR_USERNAME: ${{ secrets.NSGR_USERNAME }}
         NSGR_PASSWORD: ${{ secrets.NSGR_PASSWORD }}
@@ -48,7 +48,7 @@ jobs:
         echo "PASSWORD=${NSGR_PASSWORD}" >> nsgrest.conf
         echo "APPID=${NSGR_APPID}" >> nsgrest.conf
 
-    - name: Set up config: windows
+    - name: Set up config windows
       env:
         NSGR_USERNAME: ${{ secrets.NSGR_USERNAME }}
         NSGR_PASSWORD: ${{ secrets.NSGR_PASSWORD }}
@@ -72,12 +72,12 @@ jobs:
       run: |
         nsgr_job -c nsgrest.conf -l
 
-    - name: Test submission: non windows
+    - name: Test submission non windows
       if: ${{ matrix.runs-on != 'windows-latest'  }}
       run: |
         cd example && nsgr_submit -c ../nsgrest.conf . validate && nsgr_submit -c ../nsgrest.conf . run && cd NGBW* && tar -xvf output.tar.gz && echo "" && echo "" && echo "Output file contents:" && echo "" && cd example_dir && cat output.txt
 
-    - name: Test submission: windows
+    - name: Test submission windows
       if: ${{ matrix.runs-on == 'windows-latest'  }}
       run: |
         cd example && nsgr_submit -c ..\nsgrest.conf . validate && nsgr_submit -c ..\nsgrest.conf . run && cd NGBW* && tar -xvf output.tar.gz && echo "" && echo "" &&  echo "Output file contents:" && echo "" && cd example_dir && cat output.txt

--- a/pynsgr/client.py
+++ b/pynsgr/client.py
@@ -453,7 +453,7 @@ class Application(object):
             raise
     """
 
-    def __init__(self, conf_filepath):
+    def __init__(self, conf_filepath=None):
         found = False
         OSB2_USER_DIR = (
             "/opt/user"  # OSBv2 user's directory shared across all their workspaces

--- a/pynsgr/client.py
+++ b/pynsgr/client.py
@@ -453,7 +453,7 @@ class Application(object):
             raise
     """
 
-    def __init__(self):
+    def __init__(self, conf_filepath):
         found = False
         OSB2_USER_DIR = (
             "/opt/user"  # OSBv2 user's directory shared across all their workspaces
@@ -465,22 +465,41 @@ class Application(object):
                 self.props.load(infile)
 
             found = True
-        except IOError as e:
+        except IOError:
             pass
 
+        if conf_filepath is not None:
+            try:
+                with open(conf_filepath) as infile:
+                    self.props.load(infile)
+                found = True
+            except IOError:
+                print(f"Could not find specified configuration file at {conf_filepath}, trying default locations.")
+                pass
+
+        # look for ~/.CONF_FILENAME
+        confFile = os.path.join(os.path.expanduser("~"), f".{CONF_FILENAME}")
+        try:
+            with open(confFile) as infile:
+                self.props.load(infile)
+            found = True
+        except IOError:
+            pass
+
+        # look for ~/CONF_FILENAME (no dot)
         confFile = os.path.join(os.path.expanduser("~"), CONF_FILENAME)
         try:
             with open(confFile) as infile:
                 self.props.load(infile)
             found = True
-        except IOError as e:
+        except IOError:
             pass
 
         requiredProperties = set(["APPNAME", "APPID", "USERNAME", "PASSWORD", "URL"])
         if not found:
             raise Exception(
-                "Didn't find the file: %s (which should contain properties %s) in user's the home directory (or %s on Open Source Brain v2)."
-                % (CONF_FILENAME, requiredProperties, OSB2_USER_DIR)
+                "Didn't find the file: ~/.%s or ~/%s (which should contain properties %s) or %s/%s on Open Source Brain v2."
+                % (CONF_FILENAME, CONF_FILENAME, requiredProperties, OSB2_USER_DIR, CONF_FILENAME)
             )
 
         if not requiredProperties.issubset(self.props.propertyNames()):

--- a/pynsgr/commands/nsgr_job.py
+++ b/pynsgr/commands/nsgr_job.py
@@ -15,22 +15,30 @@ import requests
 
 
 def nsgr_job(argv):
-    """
+    f"""
     nsgr_job OPTIONS
 
     Where OPTIONS are:
 
     -h
         help
+    -c
+        path to config file
+
+        By default, it looks in the users's home directory (~) for .{CipresClient.CONF_FILENAME}, then for {CipresClient.CONF_FILENAME} (without a dot)
+
     -l
         list all the user's jobs
+
     -j JOBHANDLE
         choose a job to act upon.  If no other action (like download) is selected, shows the job's status.
+
     -d results_directory
         download job results to specified directory.  Directory (but not intermediate directories) will
         be created if it doesn't exist.
 
         Use with -j to specify the job.
+
     -v
         verbose (use with -l to get a verbose job listing)
 
@@ -48,18 +56,21 @@ def nsgr_job(argv):
         nsgr_job -j JOBHANDLE -r
             cancel and remove the specified job.
     """
+    conf_filepath = None
     jobHandle = None
     verbose = False
     action = "status"
     resultsdir = None
     try:
-        options, remainder = getopt.getopt(argv[1:], "j:hld:vr")
+        options, remainder = getopt.getopt(argv[1:], "j:hld:vrc:")
     except getopt.GetoptError as ge:
         print(ge)
         return 1
     for opt, arg in options:
         if opt in ("-j"):
             jobHandle = arg
+        elif opt in ("-c"):
+            conf_filepath = arg
         elif opt in ("-h"):
             print((nsgr_job.__doc__))
             return 0
@@ -73,7 +84,7 @@ def nsgr_job(argv):
         elif opt in ("-v"):
             verbose = True
 
-    properties = CipresClient.Application().getProperties()
+    properties = CipresClient.Application(conf_filepath).getProperties()
     client = CipresClient.Client(
         properties.APPNAME,
         properties.APPID,

--- a/pynsgr/commands/nsgr_job.py
+++ b/pynsgr/commands/nsgr_job.py
@@ -15,7 +15,7 @@ import requests
 
 
 def nsgr_job(argv):
-    f"""
+    """
     nsgr_job OPTIONS
 
     Where OPTIONS are:
@@ -25,7 +25,7 @@ def nsgr_job(argv):
     -c
         path to config file
 
-        By default, it looks in the users's home directory (~) for .{CipresClient.CONF_FILENAME}, then for {CipresClient.CONF_FILENAME} (without a dot)
+        By default, it looks in the users's home directory (~) for .nsgrest.conf, then for nsgrest.conf (without a dot)
 
     -l
         list all the user's jobs

--- a/pynsgr/commands/nsgr_job.py
+++ b/pynsgr/commands/nsgr_job.py
@@ -154,12 +154,13 @@ def nsgr_job(argv):
     except ET.ParseError as pe:
         print("Unexpected response cannot be parsed.  Parsing error message: %s" % (pe))
         return 2
+    return 0
 
 
 # required because console scripts cannot take argument lists
 def main():
     """Main runner"""
-    nsgr_job(sys.argv)
+    sys.exit(nsgr_job(sys.argv))
 
 
 if __name__ == "__main__":

--- a/pynsgr/commands/nsgr_submit.py
+++ b/pynsgr/commands/nsgr_submit.py
@@ -121,7 +121,7 @@ def nsgr_submit(argv):
 # required because console scripts cannot take argument lists
 def main():
     """Main runner"""
-    nsgr_submit(sys.argv)
+    sys.exit(nsgr_submit(sys.argv))
 
 
 if __name__ == "__main__":

--- a/pynsgr/commands/nsgr_submit.py
+++ b/pynsgr/commands/nsgr_submit.py
@@ -39,6 +39,16 @@ def nsgr_submit(argv):
     if not argv or len(argv) < 3:
         print(nsgr_submit.__doc__)
         return 1
+
+    # get config file path and remove from list
+    try:
+        c_path = argv.index("-c")
+        argv.pop(c_path)
+        conf_filepath = argv[c_path]
+        argv.pop(c_path)
+    except ValueError:
+        conf_filepath = None
+
     template = argv[1]
     action = argv[2]
     if not os.path.isdir(template):
@@ -53,7 +63,7 @@ def nsgr_submit(argv):
     if len(argv) > 3:
         resultsdir = argv[3]
 
-    properties = CipresClient.Application().getProperties()
+    properties = CipresClient.Application(conf_filepath).getProperties()
     client = CipresClient.Client(
         properties.APPNAME,
         properties.APPID,

--- a/pynsgr/commands/nsgr_submit.py
+++ b/pynsgr/commands/nsgr_submit.py
@@ -20,6 +20,11 @@ def nsgr_submit(argv):
     Where TEMPLATE_DIRECTORY is the name of a directory that contains the job's input data files and
     two property files named testInput.properties and testParam.properties.
 
+    -c
+        path to config file
+
+        By default, it looks in the users's home directory (~) for .nsgrest.conf, then for nsgrest.conf (without a dot)
+
     validate
         Ask's the REST API whether the job is valid.  If valid, prints to stdout, the command line that
         would be run on the execution host if the job were submitted to run.  If invalid, prints an


### PR DESCRIPTION
…ocations

If `-c <path>` is provided, it will look there first. If not provided, or if it could not read the file at the provided path, it will look at the default locations: `~/.nsgrest.conf` and `~/nsgrest.conf` (without a dot) in order.